### PR TITLE
Improve/adfs login form

### DIFF
--- a/src/contents/components/SaveDialog.tsx
+++ b/src/contents/components/SaveDialog.tsx
@@ -113,7 +113,7 @@ export const SaveDialog = () => {
             <Stack gap={0.5} mb={2}>
               <FormControl sx={{ mt: 1 }} variant="outlined">
                 <InputLabel htmlFor="scombz-utilities-username">Username</InputLabel>
-                <Input size="small" id="scombz-utilities-username" ref={idRef} />
+                <Input size="small" id="scombz-utilities-username" ref={idRef} type="email" autoComplete="email" />
               </FormControl>
               <FormControl sx={{ mt: 1 }} variant="outlined">
                 <InputLabel htmlFor="scombz-utilities-password">Password</InputLabel>
@@ -121,6 +121,7 @@ export const SaveDialog = () => {
                   id="scombz-utilities-password"
                   ref={passRef}
                   type={showPassword ? "text" : "password"}
+                  autoComplete="password"
                   endAdornment={
                     <InputAdornment position="end">
                       <IconButton onClick={handleClickShowPassword} onMouseDown={handleMouseDownPassword}>

--- a/src/contents/components/SaveDialog.tsx
+++ b/src/contents/components/SaveDialog.tsx
@@ -112,11 +112,11 @@ export const SaveDialog = () => {
             </Box>
             <Stack gap={0.5} mb={2}>
               <FormControl sx={{ mt: 1 }} variant="outlined">
-                <InputLabel htmlFor="scombz-utilities-username">Username</InputLabel>
+                <InputLabel htmlFor="scombz-utilities-username">あなたのユーザ名@sic</InputLabel>
                 <Input size="small" id="scombz-utilities-username" ref={idRef} type="email" autoComplete="email" />
               </FormControl>
               <FormControl sx={{ mt: 1 }} variant="outlined">
-                <InputLabel htmlFor="scombz-utilities-password">Password</InputLabel>
+                <InputLabel htmlFor="scombz-utilities-password">パスワード</InputLabel>
                 <Input
                   id="scombz-utilities-password"
                   ref={passRef}

--- a/src/contents/components/SaveDialog.tsx
+++ b/src/contents/components/SaveDialog.tsx
@@ -129,6 +129,12 @@ export const SaveDialog = () => {
                       </IconButton>
                     </InputAdornment>
                   }
+                  sx={{
+                    // ref: https://learn.microsoft.com/ja-jp/microsoft-edge/web-platform/password-reveal#visibility-of-the-control
+                    "& *::-ms-reveal": {
+                      display: "none",
+                    },
+                  }}
                 />
               </FormControl>
             </Stack>

--- a/src/contents/components/SaveDialog.tsx
+++ b/src/contents/components/SaveDialog.tsx
@@ -140,14 +140,9 @@ export const SaveDialog = () => {
             </Stack>
             <Box sx={{ display: "flex" }}>
               <Box sx={{ display: "flex", alignItems: "center" }}>
-                <IconButton onClick={closeDialog} id="scombz-utilities-close">
-                  <MdCloseFullscreen />
-                </IconButton>
-                <label htmlFor="scombz-utilities-close">
-                  <Typography variant={"subtitle1"} color={"gray"}>
-                    {chrome.i18n.getMessage("dialogClose")}
-                  </Typography>
-                </label>
+                <Button onClick={closeDialog} variant={"text"} startIcon={<MdCloseFullscreen />}>
+                  {chrome.i18n.getMessage("dialogClose")}
+                </Button>
               </Box>
               <Box
                 sx={{
@@ -175,14 +170,9 @@ export const SaveDialog = () => {
             </Box>
           </form>
         ) : (
-          <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-            <IconButton onClick={() => setOpen(true)} id="scombz-utilities-open">
-              <MdOpenInFull />
-            </IconButton>
-            <label htmlFor="scombz-utilities-open">
-              <Typography variant={"subtitle1"}>{chrome.i18n.getMessage("dialogClickToOpen")}</Typography>
-            </label>
-          </Box>
+          <Button onClick={() => setOpen(true)} startIcon={<MdOpenInFull />}>
+            {chrome.i18n.getMessage("dialogClickToOpen")}
+          </Button>
         )}
       </Stack>
     </>


### PR DESCRIPTION
## 概要

自動ログインのためのSaveDialogコンポーネントに対する改善

## スクリーンショット（変更の場合は変更前と変更後が分かるように）

## 破壊的変更があるか(あれば内容を記載)

なし

## チェック項目

- [x] ビルドが通る
- [x] lintが通る
- [ ] 作成した機能がDev環境で想定通りに動作する
- [ ] 作成した機能がビルド環境で想定通りに動作する
- [ ] 複雑なコードにはコメントを記載してある

## リリースノートへの記述

### 種別

optimisation - 既存機能修正・最適化

### タイトル

軽微な変更のため不要

### 詳細

- inputタグに`autoComplete`属性を付与することでパスワードマネージャーなどによる自動入力に対応しました
- Microsoft Edgeで開いた際パスワードの表示切り替えボタンが二重で表示される不具合を修正しました
    - <img width="551" alt="スクリーンショット 2024-05-08 15 34 59" src="https://github.com/yudai1204/scombz-utilities-react/assets/51036153/42eb4b0f-f49e-447f-a40b-6e7a84e8ac57">
- 入力フォームの拡大/縮小ボタンのスタイルを改善しました