### PR TITLE
現在時刻を秒単位で表示する機能

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -430,5 +430,17 @@
   "optionDescriptionDisplayClassroom": {
     "message": "Always display classrooms on the Timetable Widget.",
     "description": "メニュー横ウィジェットの時間割に、常に各科目の教室情報を表示します。 なお、日別表示の際はこの項目にかかわらず教室情報が表示されます。"
+  },
+  "optionTitleTimeTableTopDate": {
+    "message": "Display Date on the Timetable Widget",
+    "description": "時間割ウィジェット 今日の日付・時刻表示"
+  },
+  "optionDescriptionTimeTableTopDate": {
+    "message": "Display today's date or time in seconds at the top of the Timetable Widget.",
+    "description": "メニュー横ウィジェットの時間割の上部に、今日の日付もしくは時刻を表示します。 時刻は秒単位(HH:mm:ss)で表示されます。"
+  },
+  "notSelected": {
+    "message": "Please select",
+    "description": "未選択"
   }
 }

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -430,5 +430,17 @@
   "optionDescriptionDisplayClassroom": {
     "message": "メニュー横ウィジェットの時間割に、常に各科目の教室情報を表示します。 なお、日別表示の際はこの項目にかかわらず教室情報が表示されます。",
     "description": "メニュー横ウィジェットの時間割に、常に各科目の教室情報を表示します。 なお、日別表示の際はこの項目にかかわらず教室情報が表示されます。"
+  },
+  "optionTitleTimeTableTopDate": {
+    "message": "時間割ウィジェット 今日の日付・時刻表示",
+    "description": "時間割ウィジェット 今日の日付・時刻表示"
+  },
+  "optionDescriptionTimeTableTopDate": {
+    "message": "メニュー横ウィジェットの時間割の上部に、今日の日付もしくは時刻を表示します。 時刻は秒単位(HH:mm:ss)で表示されます。",
+    "description": "メニュー横ウィジェットの時間割の上部に、今日の日付もしくは時刻を表示します。 時刻は秒単位(HH:mm:ss)で表示されます。"
+  },
+  "notSelected": {
+    "message": "未選択",
+    "description": "未選択"
   }
 }

--- a/src/backgrounds/migration.ts
+++ b/src/backgrounds/migration.ts
@@ -172,7 +172,7 @@ export const migrateLogic = (oldSaves: any): Saves => {
   newSaves.settings.forceNarrowTimeTable = defaultSaves.settings.forceNarrowTimeTable;
   newSaves.settings.displayClassroom = defaultSaves.settings.displayClassroom;
   newSaves.settings.displayTime = defaultSaves.settings.displayTime;
-  newSaves.settings.displayTodayDate = defaultSaves.settings.displayTodayDate;
+  newSaves.settings.timeTableTopDate = defaultSaves.settings.timeTableTopDate;
   newSaves.settings.highlightToday = oldSaves?.styleNowPeriod ?? defaultSaves.settings.highlightToday;
   newSaves.settings.highlightTask = oldSaves?.highlightDeadline ?? defaultSaves.settings.highlightTask;
   newSaves.settings.deadlineMode = oldSaves?.deadlinemode?.includes("relative")

--- a/src/contents/components/TimeTable.tsx
+++ b/src/contents/components/TimeTable.tsx
@@ -379,7 +379,7 @@ export const TimeTable = (props: Props) => {
 
   const setTimeTableTopString = (lang: string, formatType: "date" | "time") => {
     if (lang === "ja") {
-      const format = formatType === "date" ? "yyyy年MM月dd日(E)" : "MM月dd日(E) HH:mm:ss";
+      const format = formatType === "date" ? "yyyy年MM月dd日(E)" : "M月d日(E) HH:mm:ss";
       setToday(formatDate(new Date(), format, { locale: ja }));
     } else {
       const format = formatType === "date" ? "EEEE, MMMM dd, yyyy" : "EEE, MMM d h:mm:ss a";

--- a/src/contents/components/TimeTable.tsx
+++ b/src/contents/components/TimeTable.tsx
@@ -408,7 +408,6 @@ export const TimeTable = (props: Props) => {
   useEffect(() => {
     if (timeTableTopDate !== "time") return;
     const interval = setInterval(() => {
-      console.log(timeTableTopDate);
       setTimeTableTopString(chrome.i18n.getUILanguage(), timeTableTopDate);
     }, 1000);
     return () => clearInterval(interval);

--- a/src/contents/components/TimeTable.tsx
+++ b/src/contents/components/TimeTable.tsx
@@ -359,6 +359,8 @@ export const TimeTable = (props: Props) => {
   const [highlightToday, setHighlightToday] = useState<boolean>(true);
   const [today, setToday] = useState<string | false>(false);
 
+  const [timeTableTopDate, setTimeTableTopDate] = useState<typeof defaultSaves.settings.timeTableTopDate>("date");
+
   const [isTimeTableOpen, setIsTimeTableOpen] = useState<boolean>(true);
   const toggleTimeTable = () => {
     setIsTimeTableOpen(!isTimeTableOpen);
@@ -375,15 +377,24 @@ export const TimeTable = (props: Props) => {
     save();
   };
 
+  const setTimeTableTopString = (lang: string, formatType: "date" | "time") => {
+    if (lang === "ja") {
+      const format = formatType === "date" ? "yyyy年MM月dd日(E)" : "MM月dd日(E) HH:mm:ss";
+      setToday(formatDate(new Date(), format, { locale: ja }));
+    } else {
+      const format = formatType === "date" ? "EEEE, MMMM dd, yyyy" : "EEE, MMM d h:mm:ss a";
+      setToday(formatDate(new Date(), format));
+    }
+  };
+
   useEffect(() => {
     const fetchTimetable = async () => {
       const currentData = (await chrome.storage.local.get(defaultSaves)) as Saves;
-      if (currentData.settings.displayTodayDate) {
-        if (chrome.i18n.getUILanguage() === "ja") {
-          setToday(formatDate(new Date(), "yyyy年MM月dd日(E)", { locale: ja }));
-        } else {
-          setToday(formatDate(new Date(), "EEEE, MMMM dd, yyyy"));
-        }
+      if (currentData.settings.timeTableTopDate) {
+        setTimeTableTopString(chrome.i18n.getUILanguage(), currentData.settings.timeTableTopDate);
+        setTimeout(() => {
+          setTimeTableTopDate(currentData.settings.timeTableTopDate);
+        }, 1000 - new Date().getMilliseconds());
       }
       setIsWideTimeTable(!currentData.settings.forceNarrowTimeTable);
       setTimetable(currentData.scombzData.timetable);
@@ -393,6 +404,15 @@ export const TimeTable = (props: Props) => {
     };
     fetchTimetable();
   }, []);
+
+  useEffect(() => {
+    if (timeTableTopDate !== "time") return;
+    const interval = setInterval(() => {
+      console.log(timeTableTopDate);
+      setTimeTableTopString(chrome.i18n.getUILanguage(), timeTableTopDate);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [timeTableTopDate]);
 
   const { day: nowDay, time: nowClassTime } = useMemo(
     () => (highlightToday ? getTimetablePosFromTime(new Date()) : { day: null, time: null }),

--- a/src/options/components/CustomSelect.tsx
+++ b/src/options/components/CustomSelect.tsx
@@ -22,7 +22,12 @@ export const CustomSelect = (props: Props) => {
   const { label, caption, id = "", options, value, onChange } = props;
   return (
     <CustomContainerParent label={label} caption={caption} id={id}>
-      <Select variant="outlined" size="small" sx={{ width: 450 }} value={value} onChange={onChange}>
+      <Select variant="outlined" size="small" sx={{ width: 450 }} value={value || "unselected"} onChange={onChange}>
+        {(value === null || value === undefined) && (
+          <MenuItem key="none" value="unselected" disabled>
+            <em>{chrome.i18n.getMessage("notSelected")}</em>
+          </MenuItem>
+        )}
         {options.map((option) => (
           <MenuItem key={option.value} value={option.value}>
             {option.label}

--- a/src/options/components/RecommendedOptions.tsx
+++ b/src/options/components/RecommendedOptions.tsx
@@ -102,6 +102,18 @@ export const RecommendedOptions = (props: Props) => {
             value={saves.settings.displayClassroom}
             onChange={(_e, checked) => setSettings("displayClassroom", checked)}
           />
+          <CustomSelect
+            label={chrome.i18n.getMessage("optionTitleTimeTableTopDate")}
+            caption={chrome.i18n.getMessage("optionDescriptionTimeTableTopDate")}
+            id="timeTableTopDate"
+            value={saves.settings.timeTableTopDate.toString()}
+            options={[
+              { value: "date", label: "日付 / Date" },
+              { value: "time", label: "時刻（秒単位）/ Time in seconds" },
+              { value: "false", label: "非表示 / Hidden" },
+            ]}
+            onChange={(e, _) => setSettings("timeTableTopDate", e.target.value === "false" ? false : e.target.value)}
+          />
         </OptionGroup>
 
         <OptionGroup title="LMS">

--- a/src/options/components/WidgetOptions.tsx
+++ b/src/options/components/WidgetOptions.tsx
@@ -255,7 +255,7 @@ export const WidgetOptions = (props: Props) => {
           <CustomSelect
             label="時間割 今日の日付・時刻表示"
             caption={`メニュー横ウィジェットの時間割の上部に、今日の日付もしくは時刻を表示します。 時刻は秒単位(HH:mm:ss)で表示されます。`}
-            id="displayTodayDate"
+            id="timeTableTopDate"
             value={saves.settings.timeTableTopDate.toString()}
             options={[
               { value: "date", label: "日付" },

--- a/src/options/components/WidgetOptions.tsx
+++ b/src/options/components/WidgetOptions.tsx
@@ -252,12 +252,17 @@ export const WidgetOptions = (props: Props) => {
             value={saves.settings.displayTime}
             onChange={(_e, checked) => setSettings("displayTime", checked)}
           />
-          <CustomSwitch
-            label="時間割 今日の日付表示"
-            caption={`メニュー横ウィジェットの時間割の上部に、今日の日付を表示します。`}
+          <CustomSelect
+            label="時間割 今日の日付・時刻表示"
+            caption={`メニュー横ウィジェットの時間割の上部に、今日の日付もしくは時刻を表示します。 時刻は秒単位(HH:mm:ss)で表示されます。`}
             id="displayTodayDate"
-            value={saves.settings.displayTodayDate}
-            onChange={(_e, checked) => setSettings("displayTodayDate", checked)}
+            value={saves.settings.timeTableTopDate.toString()}
+            options={[
+              { value: "date", label: "日付" },
+              { value: "time", label: "時刻（秒単位）" },
+              { value: "false", label: "非表示" },
+            ]}
+            onChange={(e, _) => setSettings("timeTableTopDate", e.target.value === "false" ? false : e.target.value)}
           />
           <CustomSwitch
             label="時間割 現在の授業を目立たせる"

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -31,7 +31,7 @@ export type Settings = {
   forceNarrowTimeTable: boolean;
   displayClassroom: boolean; // 常に教室を表示する
   displayTime: boolean; // 常に開始終了時間を表示する
-  displayTodayDate: boolean; // 今日の日付を表示する
+  timeTableTopDate: "date" | "time" | false; // 時間割の上部に表示する日付
   highlightToday: boolean; // 今日の日付をハイライトする(TimeTable)
   highlightTask: boolean; // タスクを色でハイライトする
   deadlineMode: "relative" | "absolute"; // 締切表示モード
@@ -104,7 +104,7 @@ export const defaultSettings: Settings = {
   forceNarrowTimeTable: false,
   displayClassroom: false,
   displayTime: true,
-  displayTodayDate: true,
+  timeTableTopDate: "date",
   highlightToday: true,
   highlightTask: true,
   deadlineMode: "relative",


### PR DESCRIPTION
## 概要

- [ ] 時間割上部に表示できる日付を、秒単位の時刻に変更できるようにした

## 関連Issue

## スクリーンショット（変更の場合は変更前と変更後が分かるように）
<img width="603" alt="スクリーンショット 2024-05-10 19 00 17" src="https://github.com/yudai1204/scombz-utilities-react/assets/59430508/a5d02411-acd7-472d-9c64-4ef973aa4ebb">

## 破壊的変更があるか(あれば内容を記載)

- [ ] YES
- [x] NO

## チェック項目

- [x] ビルドが通る
- [x] lintが通る
- [x] 作成した機能がDev環境で想定通りに動作する
- [x] 作成した機能がビルド環境で想定通りに動作する
- [ ] 複雑なコードにはコメントを記載してある

## リリースノートへの記述

- 「リリースノートへの記述」項目の種別は1つのみ選択してください。複数の機能をアップデートした場合は、それぞれに対してタイトルと詳細を記述してください。
- https://scombz-utilities.com/updates.html に記述される内容です。誰にでもわかりやすく端的に説明してください。技術的な要件についてではなく、ユーザーにとってどういった変更があったのかわかりやすく記述して下さい。

### 種別

- [ ] optimisation - 既存機能修正・最適化
- [ ] bugfix - バグ修正
- [x] newfunc - 新機能追加
- [ ] style - スタイル変更
- [ ] else - その他

### タイトル

例: オプションのインポート及びエクスポート機能の追加
例: 一部機能の追加・修正

### 詳細

例: オプションページで行う設定を、1つのファイルとしてエクスポートする機能を追加しました。また、その設定を一括で読み込むことができるインポート機能を実装しました。

例: より快適にScombZを使えるために、一部のスクリプトをより効率的なものに修正しました。また、一部の科目名がうまく取得できない問題を修正しました。

## コメント
